### PR TITLE
Add shell.nix, ignore direnv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ harmony-key.pub
 .ninja_log
 .version.json
 config.hcl
+.direnv
+.envrc

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+mkShell {
+  buildInputs = [ vips protobuf ];
+  nativeBuildInputs = [ go ];
+  shellHook = ''
+    export PROTOC=${protobuf}/bin/protoc
+    export PROTOC_INCLUDE=${protobuf}/include
+  '';
+}


### PR DESCRIPTION
This PR adds a `shell.nix` file which is used with Nix to setup a development environment. Also adds `.envrc` and `.direnv` to `.gitignore` since those files should be ignored (they come from https://direnv.net/).